### PR TITLE
Stylelia: Cookstyle 7.25.6 updates

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,12 +1,12 @@
-name             "snort"
+name             'snort'
 maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
-description      "Installs Snort IDS packages"
+description      'Installs Snort IDS packages'
 version          '5.0.2'
 chef_version     '>= 15.0'
-source_url       "https://github.com/sous-chefs/snort"
-issues_url       "https://github.com/sous-chefs/snort/issues"
+source_url       'https://github.com/sous-chefs/snort'
+issues_url       'https://github.com/sous-chefs/snort/issues'
 
 %w(ubuntu debian redhat centos fedora scientific amazon oracle).each do |os|
   supports os


### PR DESCRIPTION
Hi!

I ran Cookstyle 7.25.6 against this repo and here are the results.

Summary:
Offence Count: 5

Changes:
Issue found and resolved with metadata.rb

Prefer single-quoted strings when you don't need string interpolation or special symbols.

Issue found and resolved with metadata.rb

Prefer single-quoted strings when you don't need string interpolation or special symbols.

Issue found and resolved with metadata.rb

Prefer single-quoted strings when you don't need string interpolation or special symbols.

Issue found and resolved with metadata.rb

Prefer single-quoted strings when you don't need string interpolation or special symbols.

Issue found and resolved with resources/compile.rb

Resource properties marked as name properties should not also be required properties

