### PR TITLE
Stylelia: Cookstyle 7.25.6 updates

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name             "snort"
+name             'snort'
 maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,4 +1,4 @@
-use_inline_resources
+
 #
 # Cookbook:: snort
 # Resource:: install

--- a/resources/rules.rb
+++ b/resources/rules.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook snort
-# Resource rules
+# Cookbook:: snort
+# Resource:: rules
 #
-# Copyright 2010-2017, Chef Software, Inc
+# Copyright:: 2010-2017, Chef Software, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hi!

I ran Cookstyle 7.25.6 against this repo and here are the results.

Summary:
Offence Count: 6

Changes:
Issue found and resolved with metadata.rb

- Prefer single-quoted strings when you don't need string interpolation or special symbols.

Issue found and resolved with resources/compile.rb

- Resource properties marked as name properties should not also be required properties

Issue found and resolved with resources/install.rb

- use_inline_resources is now the default for resources in Chef Infra Client 13+ and does not need to be specified.

Issue found and resolved with resources/rules.rb

- Properly format header comments
- Properly format header comments
- Properly format header comments
